### PR TITLE
add function to get all timezones

### DIFF
--- a/src/Camroncade/Timezone/Timezone.php
+++ b/src/Camroncade/Timezone/Timezone.php
@@ -150,6 +150,11 @@ class Timezone {
 	    '(UTC+13:00) Nuku\'alofa' => 'Pacific/Tongatapu'
 	);
 
+    public function getTimezones()
+    {
+        return $this->timezoneList;
+    }
+    
 	public function selectForm($selected = null, $placeholder = null, array $selectAttributes = [], array $optionAttributes = [] )
 	{
 		$selectAttributesString = '';


### PR DESCRIPTION
Added a new function to return the $timezoneList array. Useful when showing which timezone is saved in the database.

E.g.
'(UTC+10:00) Melbourne' instead of 'Australia/Melbourne'.

Controller:
public function show() {
    $client = Client::with('Type')->find($id);
    $this->data['client'] = $client;
    $this->data['timezonelist'] = array_flip(Timezone::getTimezones());
    
    return View::make('clients.show', $this->data);
}

View:
{{ $timezonelist[$client->timezone] }}